### PR TITLE
Fixar as dependencias do Doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
     "guzzlehttp/guzzle"        : "6.3.3",
     "jms/serializer"           : "1.3.1",
     "doctrine/collections"     : "v1.3.0",
-    "doctrine/cache"           : "v1.6.0"
+    "doctrine/cache"           : "v1.6.0",
+    "doctrine/instantiator"    : "1.0.4",
+    "doctrine/annotations"     : "v1.4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "5.5.*"


### PR DESCRIPTION
Fixar versoes das dependencias:
"doctrine/instantiator"    : "1.0.4",
 "doctrine/annotations"  : "v1.4.0"

Problema esta ocorrendo com quem utiliza o PHP 5.6

Referente a Issue #9 
