### PR TITLE
Corrige conflitos com pacotes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "doctrine/annotations"     : "^v1.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5.*"
+    "phpunit/phpunit": "^5.5.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,10 @@
   "require": {
     "php"                      : ">=5.6",
     "guzzlehttp/guzzle"        : "6.3.3",
-    "jms/serializer"           : "1.3.1",
-    "doctrine/collections"     : "^v1.3.0",
-    "doctrine/cache"           : "^v1.6.0",
-    "doctrine/instantiator"    : "^1.0.4",
-    "doctrine/annotations"     : "^v1.4.0"
+    "jms/serializer"           : "1.3.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5.0"
+    "phpunit/phpunit": "^7.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "doctrine/annotations"     : "^v1.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^5.5.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "php"                      : ">=5.6",
     "guzzlehttp/guzzle"        : "6.3.3",
     "jms/serializer"           : "1.3.1",
-    "doctrine/collections"     : "v1.3.0",
-    "doctrine/cache"           : "v1.6.0",
-    "doctrine/instantiator"    : "1.0.4",
-    "doctrine/annotations"     : "v1.4.0"
+    "doctrine/collections"     : "^v1.3.0",
+    "doctrine/cache"           : "^v1.6.0",
+    "doctrine/instantiator"    : "^1.0.4",
+    "doctrine/annotations"     : "^v1.4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.5.*"
+    "phpunit/phpunit": "^5.5.*"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
   "require": {
     "php"                      : ">=5.6",
     "guzzlehttp/guzzle"        : "6.3.3",
-    "jms/serializer"           : "1.3.1"
+    "jms/serializer"           : "1.3.1",
+    "doctrine/collections"     : "^v1.3.0",
+    "doctrine/cache"           : "^v1.6.0",
+    "doctrine/instantiator"    : "^1.0.4",
+    "doctrine/annotations"     : "^v1.4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.0"


### PR DESCRIPTION
Com o travamento no commit 5e60012 onde fixou as versões dos pocotes, o Laravel 5.7 deixou de atualizar o dsc-mercado-livre por conta de conflitos.

Para contornar a situação, tive que adicionar para funcionar com versões maiores pois ele usa pacotes mais atualizados.

https://github.com/discovery-tecnologia/dsc-mercado-livre/issues/21