### PR TITLE
Alteração do tipo do atributo

### DIFF
--- a/src/Requests/Product/Picture.php
+++ b/src/Requests/Product/Picture.php
@@ -18,32 +18,32 @@ class Picture
     private $id;
 
     /**
-     * @var integer
-     * @JMS\Type("integer")
+     * @var string
+     * @JMS\Type("string")
      */
     private $url;
 
     /**
-     * @var integer
-     * @JMS\Type("integer")
+     * @var string
+     * @JMS\Type("string")
      */
     private $secureUrl;
 
     /**
-     * @var integer
-     * @JMS\Type("integer")
+     * @var string
+     * @JMS\Type("string")
      */
     private $size;
 
     /**
-     * @var integer
-     * @JMS\Type("integer")
+     * @var string
+     * @JMS\Type("string")
      */
     private $maxSize;
 
     /**
-     * @var integer
-     * @JMS\Type("integer")
+     * @var string
+     * @JMS\Type("string")
      */
     private $quality;
 


### PR DESCRIPTION
Nos atributos abaixo é esperado String pela a API do MercadoLivre, porém estava retornando um inteiro:
```
$url
$secureUrl
$size
$maxSize
$quality
```