### PR TITLE
Alterado formato do campo dateLastUpdated

### DIFF
--- a/src/Resources/Order/Order.php
+++ b/src/Resources/Order/Order.php
@@ -62,7 +62,7 @@ class Order
 
     /**
      * @var \DateTime
-     * @JMS\Type("DateTime<'Y-m-d\TH:i:s.uZ'>")
+     * @JMS\Type("DateTime<'Y-m-d\TH:i:s.u+'>")
      */
     private $dateLastUpdated;
 

--- a/tests/Resources/Order/OrdersSearchDateLastUpdatedTest.php
+++ b/tests/Resources/Order/OrdersSearchDateLastUpdatedTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Dsc\MercadoLivre\Resources\Order;
+
+use Dsc\MercadoLivre\Client;
+use Dsc\MercadoLivre\Environment;
+use Dsc\MercadoLivre\MeliInterface;
+use GuzzleHttp\Psr7\Stream;
+
+class OrdersSearchDateLastUpdatedTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldReturnDateLastUpdatedWithDayOfYear()
+    {
+        /** @var OrdersList */
+        $orderList = $this->getOrdersListByStream($this->getStreamByDate('2020-04-09T21:18:26.708Z'));
+
+        /** @var Order */
+        $order = $orderList->getResults()->first();
+        $this->assertInstanceOf(Order::class, $order);
+
+        $this->assertEquals("2020-04-09 21:18:26.708000", $order->getDateLastUpdated()->format('Y-m-d H:i:s.u'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldReturnDateLastUpdatedWithoutDayOfYear()
+    {
+        /** @var OrdersList */
+        $orderList = $this->getOrdersListByStream($this->getStreamByDate('2020-04-09T21:18:26.000-04:00'));
+
+        /** @var Order */
+        $order = $orderList->getResults()->first();
+        $this->assertInstanceOf(Order::class, $order);
+
+        $this->assertEquals("2020-04-09 21:18:26.000000", $order->getDateLastUpdated()->format('Y-m-d H:i:s.u'));
+    }
+
+    /**
+     * @param Stream $stream
+     * @return OrdersList
+     */
+    public function getOrdersListByStream(Stream $stream)
+    {
+        $meli = $this->createMock(MeliInterface::class);
+        $meli->expects($this->any())
+            ->method('getEnvironment')
+            ->willReturn($this->getMockForAbstractClass(Environment::class));
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->any())
+            ->method('get')
+            ->willReturn($stream);
+
+        /** @var OrderService $service */
+        $service = $this->getMockForAbstractClass(OrderService::class, [$meli, $client]);
+        return $service->findOrdersBySeller('123456');
+    }
+
+    /**
+     * @return Stream
+     */
+    public function getStreamByDate($date)
+    {
+        $json = sprintf('{"results": [{"date_last_updated": "%s"}]}', $date);
+        $stream = fopen('data://text/json,' . $json, 'r');
+        return new Stream($stream);
+    }
+}

--- a/tests/Resources/Order/OrdersSearchTest.php
+++ b/tests/Resources/Order/OrdersSearchTest.php
@@ -74,7 +74,7 @@ class OrdersSearchTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("123", $order->getStatusDetail()->getCode());
         $this->assertEquals("2020-06-15", $order->getDateCreated()->format("Y-m-d"));
         $this->assertEquals("2020-06-15", $order->getDateClosed()->format("Y-m-d"));
-        $this->assertEquals("2020-06-15UTC13:37:52", $order->getDateLastUpdated()->format("Y-m-dTH:i:s"));
+        $this->assertEquals("2020-06-15 13:37:52", $order->getDateLastUpdated()->format("Y-m-d H:i:s"));
         $this->assertEquals(10, $order->getTotalAmount());
         $this->assertEquals("ARS", $order->getCurrencyId());
         $this->assertEquals(["not_delivered", "paid"], $order->getTags());


### PR DESCRIPTION
### Pull request de referência: #49 #43 

Alteração na formato do campo `dateLastUpdated` na `Order` para atender as situações abaixo:

- Data com o número do dia do ano: `2020-04-09T21:18:26.708Z`
- Data sem o número do dia do ano: `2020-04-09T21:18:26.000-04:00`

Para corrigir esse problema de padrão do Mercado Livre, foi adicionado o caractere `+` na formatação do campo. Com isso, todo conteúdo que estiver após o último caractere válido da formatação, que no caso é o caracter `u`, será ignorado.

A formatação passou de `Y-m-d\TH:i:s.uZ` para `Y-m-d\TH:i:s.u+`.

Com isso, o comportamento do campo ficou da seguinte forma:

> Primeira situação **2020-04-09T21:18:26.708Z**

Ao formatar o campo, o resultado será o seguinte:

```php
$order->getDateLastUpdated()->format('Y-m-d H:i:s.u') == "2020-04-09 :18:26.708000"
```

> Segunda situação **2020-04-09T21:18:26.000-04:00**

Ao formatar o campo, o resultado será o seguinte:

```php
$order->getDateLastUpdated()->format('Y-m-d H:i:s.u') == "2020-04-09 21:18:26.000000"
```
--------------------------------
Link documentação PHP: https://www.php.net/manual/pt_BR/datetime.createfromformat.php


