### PR TITLE
Access-Token via Header Authorization

### DIFF
--- a/src/Handler/OAuth2ClientHandler.php
+++ b/src/Handler/OAuth2ClientHandler.php
@@ -81,12 +81,15 @@ class OAuth2ClientHandler extends Client implements HandlerInterface
 
             $token = $authorization->access_token;
         }
-
-        $oauthparams['access_token'] = $token;
+        
         $queryparams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
-        $preparedParams = \GuzzleHttp\Psr7\build_query($oauthparams + $queryparams);
+        $preparedParams = \GuzzleHttp\Psr7\build_query($queryparams);
 
-        return $request->withUri($request->getUri()->withQuery($preparedParams));
+        return $request->withHeader('Authorization', "Bearer $token")
+                       ->withUri(
+                           $request->getUri()->withQuery($preparedParams
+                        )
+                    );
     }
 
     /**


### PR DESCRIPTION
Adicionado o ajuste para envio do Access-Token via Header Authorization, conforme anuncio de mudanca feito pelo Mercado Livre (dia 1 de Abril)