### PR TITLE
Adicionado campo SellerCustomField

### DIFF
--- a/src/Requests/Product/Variation.php
+++ b/src/Requests/Product/Variation.php
@@ -60,6 +60,12 @@ class Variation
     private $pictureIds;
 
     /**
+     * @var string
+     * @JMS\Type("string")
+     */
+    private $sellerCustomField ;
+
+    /**
      * Variation constructor.
      */
     public function __construct()
@@ -217,4 +223,24 @@ class Variation
         $this->pictureIds = $pictureIds;
         return $this;
     }
+
+    /**
+     *
+     * @return string
+     */
+    public function getSellerCustomField()
+    {
+        return $this->sellerCustomField;
+    }
+
+    /**
+     * @param string $sellerCustomField
+     * @return Variation
+     */
+    public function setSellerCustomField($sellerCustomField)
+    {
+        $this->sellerCustomField = $sellerCustomField;
+        return $this;
+    }
+
 }


### PR DESCRIPTION
Conforme documentação  o campo seller_custom_field para uso interno pelo vendedor https://developers.mercadolivre.com.br/pt-br/variacoes/#:~:text=deixando%20o%20campo-,seller_custom_field,-para%20uso%20interno