### PR TITLE
Atualizado OAuth2ClientHandler.php substituindo functions do GuzzleHt…

### DIFF
--- a/src/Handler/OAuth2ClientHandler.php
+++ b/src/Handler/OAuth2ClientHandler.php
@@ -86,8 +86,8 @@ class OAuth2ClientHandler extends Client implements HandlerInterface
             $token = $authorization->access_token;
         }
         
-        $queryparams = \GuzzleHttp\Psr7\parse_query($request->getUri()->getQuery());
-        $preparedParams = \GuzzleHttp\Psr7\build_query($queryparams);
+        $queryparams = \GuzzleHttp\Psr7\Query::parse($request->getUri()->getQuery());
+        $preparedParams = \GuzzleHttp\Psr7\Query::build($queryparams);
 
         return $request->withHeader('Authorization', "Bearer $token")
                        ->withUri(


### PR DESCRIPTION
…tp deprecated: parse_query build_query

Atualizado substituindo functions do GuzzleHttp deprecated parse_query build_query


https://github.com/discovery-tecnologia/dsc-mercado-livre/issues/88